### PR TITLE
Don't throw an error when add-on type not specified.

### DIFF
--- a/mozilla_addon_signer/cli.py
+++ b/mozilla_addon_signer/cli.py
@@ -96,7 +96,8 @@ def sign(src, dest, addon_type, api_key, attach, bucket_name, env, profile, verb
 
     # Validate the addon type
     if addon_type not in ADDON_TYPES:
-        output('WARNING: You did not provide a valid addon type.\n', Fore.YELLOW)
+        if addon_type:
+            output('WARNING: You did not provide a valid addon type.\n', Fore.YELLOW)
         addon_type = prompt_choices('Addon Type', ADDON_TYPES)
 
     # Validate the environment


### PR DESCRIPTION
Before:

```
$ mozilla-addon-signer sign_from_bug 1428308
Please select one of the following:
[0] taarexpv2@shield.mozilla.org-1.0.7.xpi by fwollsen@mozilla.com

Select attachment: 0

WARNING: You did not provide a valid addon type.

Please select one of the following:
[0] system
[1] mozillaextension

Addon Type: 1

Successfully signed!
Attachment successfully created!
```

after:

```
$ mozilla-addon-signer sign_from_bug 1428308
Please select one of the following:
[0] taarexpv2@shield.mozilla.org-1.0.7.xpi by fwollsen@mozilla.com

Select attachment: 0
0

Please select one of the following:
[0] system
[1] mozillaextension

Addon Type:   1

Successfully signed!
Attachment successfully created!
```