### PR TITLE
Check for and clear needinfo flags after uploading attachment

### DIFF
--- a/mozilla_addon_signer/bugzilla.py
+++ b/mozilla_addon_signer/bugzilla.py
@@ -4,37 +4,71 @@ import requests
 class BugzillaAPI(object):
     api_base = 'https://bugzilla.mozilla.org/rest'
 
+    class APIException(Exception):
+        pass
+
     def __init__(self, api_key=None):
         self.session = requests.Session()
         if api_key:
             self.session.headers.update({'X-BUGZILLA-API-KEY': api_key})
 
-    def get(self, url, params=None):
-        res = self.session.get(self.api_base + url, params=params)
+    def request(self, method, endpoint, params=None, data=None, json=None):
+        url = self.api_base + endpoint
+        res = self.session.request(method, url, params=params, json=json, data=data)
         res.raise_for_status()
-        return res.json()
+        data = res.json()
+        if data.get('error', False):
+            raise self.APIException(data)
+        return data
 
-    def post(self, url, data=None):
-        res = self.session.post(self.api_base + url, data=data)
-        res.raise_for_status()
-        return res.json()
+    def get(self, endpoint, params=None):
+        return self.request('GET', endpoint, params=params)
+
+    def post(self, endpoint, json=None, data=None):
+        return self.request('POST', endpoint, json=json, data=data)
+
+    def put(self, endpoint, json=None, data=None):
+        return self.request('PUT', endpoint, json=json, data=data)
+
+    def get_bug(self, bug_number):
+        return Bug(self, bug_number)
 
     def get_attachments_for_bug(self, bug_number):
-        response = self.get('/bug/{}/attachment'.format(bug_number), {
-            'exclude_fields': 'data'
-        })
-        return response.get('bugs', {}).get(str(bug_number), [])
+        return self.get_bug(bug_number).get_attachments()
 
-    def get_attachment_data(self, id):
-        response = self.get('/bug/attachment/{}'.format(id), {
-            'include_fields': 'data'
-        })
-        return response.get('attachments', {}).get(str(id), {}).get('data')
+    def get_attachment_data(self, bug_number):
+        return self.get_bug(bug_number).get_attachment_data()
 
     def create_attachment_for_bug(self, bug_number, attachment_data, file_name, summary,
                                   content_type):
-        response = self.post('/bug/{}/attachment'.format(bug_number), {
-            'ids': [bug_number],
+        return (self.get_bug(bug_number)
+                .create_attachment(attachment_data, file_name, summary, content_type))
+
+    def who_am_i(self):
+        return self.get('/whoami')
+
+class Bug(object):
+
+    def __init__(self, api, bug_number):
+        self.api = api
+        assert type(bug_number) in [int, str], f'bug number must be int or str, not {type(bug_number)}'
+        self.bug_number = bug_number
+
+    def get_attachments(self):
+        response = self.api.get('/bug/{}/attachment'.format(self.bug_number), {
+            'exclude_fields': 'data'
+        })
+        return response.get('bugs', {}).get(str(self.bug_number), [])
+
+    def get_attachment_data(self):
+        response = self.api.get('/bug/attachment/{}'.format(self.bug_number), {
+            'include_fields': 'data'
+        })
+        return response.get('attachments', {}).get(str(self.bug_number), {}).get('data')
+
+    def create_attachment(self, attachment_data, file_name, summary, content_type):
+        response = self.api.post('/bug/{}/attachment'.format(self.bug_number), data={
+            'ids': [self.bug_number],
             'data': attachment_data,
             'file_name': file_name,
             'summary': summary,
@@ -42,3 +76,10 @@ class BugzillaAPI(object):
         })
         return response
 
+    def get_flags(self):
+        response = self.api.get('/bug/{}'.format(self.bug_number), {'include_fields': 'flags'})
+        return response['bugs'][0]['flags']
+
+    def set_flags(self, flags):
+        response = self.api.put('/bug/{}'.format(self.bug_number), {"flags": flags})
+        return response

--- a/mozilla_addon_signer/cli.py
+++ b/mozilla_addon_signer/cli.py
@@ -197,6 +197,7 @@ def sign(ctx, src, dest, addon_type, api_key, attach, bucket_name, env, profile,
 @click.option('--api-key', '-k', default=None, help='The Bugzilla API key to use.')
 @click.argument('bug_number', nargs=1)
 def check_needinfo(bug_number, api_key):
+    """Checks for an open needinfo on the given bug, and offers to clear it."""
     api_key = api_key or config.get('bugzilla.api_key', default=None)
     bz = BugzillaAPI(api_key)
     bug = bz.get_bug(bug_number)

--- a/mozilla_addon_signer/cli.py
+++ b/mozilla_addon_signer/cli.py
@@ -73,7 +73,8 @@ def configure(key, value):
 @click.option('--verbose', '-v', is_flag=True)
 @click.argument('src', nargs=1)
 @click.argument('dest', nargs=1, required=False)
-def sign(src, dest, addon_type, api_key, attach, bucket_name, env, profile, verbose):
+@click.pass_context
+def sign(ctx, src, dest, addon_type, api_key, attach, bucket_name, env, profile, verbose, **kwargs):
     """Uploads and signs an addon XPI file."""
     try:
         xpi = XPI(src)
@@ -188,6 +189,26 @@ def sign(src, dest, addon_type, api_key, attach, bucket_name, env, profile, verb
         output('Attachment successfully created!', Fore.GREEN)
     else:
         output('\n{}'.format(json.dumps(data, indent=2, sort_keys=True)))
+
+    ctx.invoke(check_needinfo, bug_number=attach, **kwargs)
+
+
+@cli.command()
+@click.option('--api-key', '-k', default=None, help='The Bugzilla API key to use.')
+@click.argument('bug_number', nargs=1)
+def check_needinfo(bug_number, api_key):
+    api_key = api_key or config.get('bugzilla.api_key', default=None)
+    bz = BugzillaAPI(api_key)
+    bug = bz.get_bug(bug_number)
+    flags = bug.get_flags()
+
+    user_email = bz.who_am_i()['name']
+    for flag in flags:
+        if flag['name'] == 'needinfo' and flag['status'] == '?' and flag['requestee'] == user_email:
+            if click.confirm('Clear your needinfo from {}?'.format(flag['setter'])):
+                bug.set_flags([{'id': flag['id'], 'status': 'X'}])
+                output('Needinfo cleared', Fore.GREEN)
+            break
 
 
 @cli.command()


### PR DESCRIPTION
I ended up refactoring some of the Bugzilla API to do this. It wasn't strict needed, but I think the separation is probably a good idea. I've tested `check_needinfo` in isolation, but I haven't fully tested the end-to-end of `sign_from_bug` with all the changes. I think it will work, but maybe we should wait on this until I have another add-on to sign?